### PR TITLE
changed baseURL to new API endpoint

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	baseURL, _ := url.Parse("http://pastebin.com/")
+	baseURL, _ := url.Parse("https://scrape.pastebin.com/")
 
 	pc := pastebin.New(baseURL)
 


### PR DESCRIPTION
Changed the pastebin scraper endpoint to the new one according to the scraper [API](https://pastebin.com/doc_scraping_api). Paths api_scraping.php and api_scrape_item.php remain the same. 
Unfortunately i can't test the script because i have no access to the scraping API  which requires a lifetime pro subscription.  
Note that "hits" in the Paste struct in pastebin.go is not offered in the API example output.