### PR TITLE
fixed scraper

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/dutchcoders/gopastebin"
 	"io/ioutil"
@@ -20,7 +21,13 @@ func main() {
 		}
 
 		for _, paste := range pastes {
-			fmt.Printf("%#v\n", paste)
+			fmt.Println("----------------")
+			fmt.Println("Scrape URL: ", paste.ScrapeURL)
+			fmt.Println("Full URL: ", paste.FullURL)
+			fmt.Println("Key: ", paste.Key)
+			fmt.Println("Title: ", paste.Title)
+			fmt.Println("User: ", paste.User)
+			fmt.Println("Syntax: ", paste.Syntax)
 
 			raw, err := pc.GetRaw(paste.Key)
 			if err != nil {
@@ -31,10 +38,11 @@ func main() {
 			defer raw.Close()
 
 			b, err := ioutil.ReadAll(raw)
+			b = bytes.Replace([]byte(b), []byte(`\r\n`), []byte("\n"), -1)
+			b = bytes.Replace([]byte(b), []byte(`\n`), []byte("\n"), -1)
 
 			fmt.Println("----------------")
-			fmt.Printf("%#v\n", string(b))
-			fmt.Println("----------------")
+			fmt.Printf("%s\n", b)
 		}
 		time.Sleep(time.Second * 60)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	baseURL, _ := url.Parse("http://pastebin.com/")
+	baseURL, _ := url.Parse("https://scrape.pastebin.com/")
 
 	pc := pastebin.New(baseURL)
 

--- a/pastebin.go
+++ b/pastebin.go
@@ -140,7 +140,7 @@ func (pc *PastebinClient) Scrape(*context.Context) (*Scrape, error) {
 */
 
 func (pc *PastebinClient) Recent(size int) ([]Paste, error) {
-	req, err := pc.NewRequest("GET", "/api_scraping.php")
+	req, err := pc.NewRequest("GET", fmt.Sprintf("/api_scraping.php?limit=%d", size))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- changed the API-endpoint to "https://scrape.pastebin.com/api_scraping.php" so the scraper works again.
- added some lines to "example/main.go" to get a prettier and more readable output.
- updated method "Recent" in pastebin.go to support number ('limit') of items scraped when the method is called. Default scrape-items is set by Pastebin at 50 but the max allowed value is 250.

Note that "?lang=" is allowed to scrape items per certain language.  